### PR TITLE
Methods to create a subspecies label for grouping

### DIFF
--- a/datamaterials_neighbors/neighbors.py
+++ b/datamaterials_neighbors/neighbors.py
@@ -13,7 +13,7 @@ from datamaterials_neighbors.structure import label_subspecies
 Neighbor = Tuple[PeriodicSite, float, int]
 SiteNeighbors = List[Optional[Neighbor]]
 AllNeighborDistances = List[SiteNeighbors]
-NeighborDistances = Dict[str, Union[List[str], List[float]]]
+NeighborDistances = Dict[str, Union[List[str], List[float], List[int]]]
 
 
 def count_neighbors_grouped_by_site_index_pairs_and_distance(
@@ -50,7 +50,7 @@ def count_neighbors_grouped_by_site_index_pairs_and_distance(
             .loc[:, "distance_ij"]
             .loc[:, ["max", "count"]]
             .reset_index()
-            .loc[:, ["i", "j", "species_i", "species_j", "max", "count"]]
+            .loc[:, ["i", "j", "subspecies_i", "subspecies_j", "max", "count"]]
             .rename(columns={"max": "distance_ij", "count": "n"})
             .assign(n=lambda x: pd.to_numeric(x["n"], downcast='integer'))
     )  # yapf: disable
@@ -70,9 +70,11 @@ def group_neighbors_within_site_index_pairs_by_distance(
     unique_distances: np.ndarray = find_unique_distances(
         distance_ij=neighbor_distances_df["distance_ij"]
     )
+
     bin_intervals: IntervalIndex = define_bin_intervals(
         unique_distances=unique_distances
     )
+
     binned_distances: Series = pd.cut(
         x=neighbor_distances_df["distance_ij"],
         bins=bin_intervals,
@@ -81,8 +83,8 @@ def group_neighbors_within_site_index_pairs_by_distance(
     return neighbor_distances_df.groupby([
         "i",
         "j",
-        "species_i",
-        "species_j",
+        "subspecies_i",
+        "subspecies_j",
         binned_distances,
     ])
 
@@ -171,8 +173,8 @@ def extract_neighbor_distance_data(
     neighbor_distances: NeighborDistances = {
         "i": [],
         "j": [],
-        "species_i": [],
-        "species_j": [],
+        "subspecies_i": [],
+        "subspecies_j": [],
         "distance_ij": [],
     }
 
@@ -209,19 +211,19 @@ def append_site_i_neighbor_distance_data(
     """
     site_j: Neighbor
     for site_j in site_i_neighbors:
-        species_pair: List[str] = sorted([
-            cell_structure[site_i_index].specie.name,
-            cell_structure[site_j[2]].specie.name,
+        subspecies_pair: List[str] = sorted([
+            cell_structure[site_i_index].properties["subspecie"],
+            cell_structure[site_j[2]].properties["subspecie"],
         ])
-        index_pair: List[str] = [site_i_index, site_j[2]]
 
+        index_pair: List[str] = [site_i_index, site_j[2]]
         if unordered_pairs:
             index_pair.sort()
 
         neighbor_distances["i"].append(index_pair[0])
         neighbor_distances["j"].append(index_pair[1])
-        neighbor_distances["species_i"].append(species_pair[0])
-        neighbor_distances["species_j"].append(species_pair[1])
+        neighbor_distances["subspecies_i"].append(subspecies_pair[0])
+        neighbor_distances["subspecies_j"].append(subspecies_pair[1])
         neighbor_distances["distance_ij"].append(site_j[1])
 
 

--- a/datamaterials_neighbors/structure.py
+++ b/datamaterials_neighbors/structure.py
@@ -55,52 +55,55 @@ def from_file(structure_file: str) -> Structure:
     return cell_structure
 
 
-def set_sublattice_parameters(
+def label_subspecies(
     cell_structure: Structure,
-    species: Union[List[str], str],
+    site_indices: Union[List[int], int] = [],
 ) -> None:
-    """Applies unique sublattice labels to sites matching the specified atomic species.
+    """Toggles subspecies grouping on the specified site indices. Sites not found in
+    the list are labeled with the atomic species name.
 
     :param cell_structure: A pymatgen ``Structure`` object.
-    :param species: An atomic specie or list of atomic species all present in
-        ``cell_structure``.
+    :param site_indices: A site index or list of site indices all present in
+        ``cell_structure`` (default []).
     """
-    if isinstance(species, str):
-        species = [species]
+    if isinstance(site_indices, int):
+        site_indices = [site_indices]
 
-    site_properties_sublattices: List[Union[str, None]] = enumerate_sublattices(
+    site_properties_subspecies: List[str] = get_subspecies_labels(
         cell_structure=cell_structure.copy(),
-        species=species,
+        site_indices=site_indices,
     )
 
     cell_structure.add_site_property(
-        property_name="sublattice",
-        values=site_properties_sublattices,
+        property_name="subspecie",
+        values=site_properties_subspecies,
     )
 
 
-def enumerate_sublattices(
+def get_subspecies_labels(
     cell_structure: Structure,
-    species: List[str],
+    site_indices: List[int],
 ) -> List[Union[str, None]]:
-    """Enumerates sublattice labels to sites matching the specified atomic species into
-    a list.
+    """Generates subspecies labels using the provided site indices. Sites not found in
+    the list are labeled with the atomic species name.
 
     :param cell_structure: A pymatgen ``Structure`` object.
-    :param species: A list of atomic species.
-    :return: A list of unique sublattice labels.
+    :param site_indices: A list of site indices.
+    :return: A list of subspecies labels.
     """
     species_counter: Counter = Counter()
-    site_properties_sublattices: List[Union[str, None]] = []
+    site_properties_subspecies: List[str] = []
 
-    for site in cell_structure:
-        specie: str = site.species_string
+    for site_index, site in enumerate(cell_structure):
+        specie_name: str = site.specie.name
 
-        if specie in species:
-            species_counter[specie] += 1
-            site_properties_sublattices.append(f"{specie}{species_counter[specie]}")
+        if site_index in site_indices:
+            species_counter[specie_name] += 1
+            site_properties_subspecies.append(
+                f"{specie_name}{species_counter[specie_name]}"
+            )
 
         else:
-            site_properties_sublattices.append(None)
+            site_properties_subspecies.append(f"{specie_name}")
 
-    return site_properties_sublattices
+    return site_properties_subspecies


### PR DESCRIPTION
## Additions and changes

1.  Refactor functions in structure module to label subspecies
    *   Rename functions to label_subspecies() and get_subspecies_labels().
    *   Rename the site property subgroup for each atomic specie from sublattice to subspecie.
    *   Use site indices to toggle subspecies labels instead of the species name.
    *   Sites not in the site indices list are labeled with the two-letter name of the site's atomic specie.
2.  Add method in neighbors module to check for subspecie label
    *   Require all structures to be processed by the neighbor counting function to have the subspecie label.
    *   If the subspecie label does not exist, create it and label each site using the site's atomic specie name.
    *   Make a copy of the input structure to prevent unexpected or unknown modification of user's structure object.
3. Propagate subspecies label through neighbor counting methods
    *   Replaces species_i and species_j with subspecies_i and subspecies_j