### PR TITLE
Release v0.2.0: Control the pairs you keep in an interaction model

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -36,6 +36,7 @@ dependencies:
   - pip:
       - ase==3.16.2
       - autopep8==1.3.5
+      - black==19.3b0
       - flake8==3.5.0
       - monty==1.0.3
       - pybtex==0.21

--- a/neighbormodels/interactions.py
+++ b/neighbormodels/interactions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -14,6 +14,7 @@ MagneticPatterns = Dict[str, Union[int, float]]
 def build_model(
     neighbor_data: NeighborData,
     magnetic_patterns: MagneticPatterns,
+    distance_filter: Optional[Dict[str, List[float]]] = None,
 ) -> DataFrame:
     """Builds and returns a data frame describing a pairwise interaction model. The
     intended use-case for the model is fitting magnetic energies taken from density
@@ -21,11 +22,11 @@ def build_model(
 
     :param neighbor_data: A named tuple with three field names:
 
-        ``data_frame``
+        ``neighbor_count``
             A pandas ``DataFrame`` of neighbor counts aggregated over site-index pairs
             and separation distances.
 
-        ``bins_data_frame``
+        ``sublattice_pairs``
             A pandas ``DataFrame`` of neighbor distances mapped to unique bin
             intervals.
 
@@ -34,6 +35,10 @@ def build_model(
     :param magnetic_patterns: A dictionary of magnetic patterns to be mapped onto
         the crystal structure and used to compute the interaction coefficients of the
         model.
+    :param distance_filter: A dictionary that defines pair distances to keep in the
+        model. Any pair not found int he dictionary is filtered out. The dictionary keys
+        define named groups of pair distances to keep, which subsequently are used for
+        naming the interaction parameters.
     :return: A pandas ``DataFrame`` of the interaction parameter names and coefficients
         for the pairwise interaction model.
     """
@@ -41,10 +46,15 @@ def build_model(
         magnetic_patterns=magnetic_patterns
     )
 
-    return magnetic_patterns_df \
-        .pipe(compute_interaction_signs) \
-        .pipe(compute_model_coefficients, neighbor_data=neighbor_data) \
+    return (
+        magnetic_patterns_df.pipe(compute_interaction_signs)
+        .pipe(
+            compute_model_coefficients,
+            neighbor_data=neighbor_data,
+            distance_filter=distance_filter,
+        )
         .pipe(spread_parameter_name_column)
+    )
 
 
 def compute_interaction_signs(magnetic_patterns_df: DataFrame) -> DataFrame:
@@ -54,20 +64,21 @@ def compute_interaction_signs(magnetic_patterns_df: DataFrame) -> DataFrame:
         magnetic patterns.
     :return: A pandas ``DataFrame`` of the signs of the pairwise interactions.
     """
-    return magnetic_patterns_df \
-        .merge(right=magnetic_patterns_df,
-               how="inner",
-               on="pattern",
-               suffixes=("_i", "_j")) \
-        .rename(columns={"site_i": "i", "site_j": "j"}) \
-        .loc[:, ["pattern", "i", "j", "spin_i", "spin_j"]] \
-        .assign(sign=lambda x: x["spin_i"] * x["spin_j"]) \
+    return (
+        magnetic_patterns_df.merge(
+            right=magnetic_patterns_df, how="inner", on="pattern", suffixes=("_i", "_j")
+        )
+        .rename(columns={"site_i": "i", "site_j": "j"})
+        .loc[:, ["pattern", "i", "j", "spin_i", "spin_j"]]
+        .assign(sign=lambda x: x["spin_i"] * x["spin_j"])
         .query("i <= j")
+    )
 
 
 def compute_model_coefficients(
     interaction_signs_df: DataFrame,
     neighbor_data: NeighborData,
+    distance_filter: Optional[Dict[str, List[float]]],
 ) -> DataFrame:
     """Computes the model coefficients by aggregating over the dot product of the
     neighbor counts and interaction signs.
@@ -76,30 +87,42 @@ def compute_model_coefficients(
         interactions.
     :param neighbor_data: A named tuple with three field names:
 
-        ``data_frame``
+        ``neighbor_count``
             A pandas ``DataFrame`` of neighbor counts aggregated over site-index pairs
             and separation distances.
 
-        ``bins_data_frame``
+        ``sublattice_pairs``
             A pandas ``DataFrame`` of neighbor distances mapped to unique bin
             intervals.
 
         ``structure``
             A copy of the ``Structure`` object defining the crystal structure.
+    :param distance_filter: A dictionary that defines pair distances to keep in the
+        model. Any pair not found int he dictionary is filtered out. The dictionary keys
+        define named groups of pair distances to keep, which subsequently are used for
+        naming the interaction parameters.
     :return: A pandas ``DataFrame`` of the model coefficients.
     """
-    return neighbor_data.data_frame \
-        .pipe(multiply_interaction_signs_and_neighbor_count,
-              interaction_signs_df=interaction_signs_df) \
-        .pipe(group_subspecie_pairs_and_rank_by_distance) \
-        .pipe(label_interaction_parameters) \
-        .pipe(aggregate_interaction_coefficients,
-              num_sites=neighbor_data.structure.num_sites)
+    return (
+        neighbor_data.neighbor_count.pipe(
+            multiply_interaction_signs_and_neighbor_count,
+            interaction_signs_df=interaction_signs_df,
+        )
+        .pipe(
+            group_subspecie_pairs_and_rank_by_distance,
+            sublattice_pairs=neighbor_data.sublattice_pairs,
+        )
+        .pipe(apply_distance_filter, distance_filter=distance_filter)
+        .pipe(label_interaction_parameters)
+        .pipe(
+            aggregate_interaction_coefficients,
+            num_sites=neighbor_data.structure.num_sites,
+        )
+    )
 
 
 def multiply_interaction_signs_and_neighbor_count(
-    data_frame: DataFrame,
-    interaction_signs_df: DataFrame,
+    data_frame: DataFrame, interaction_signs_df: DataFrame
 ) -> DataFrame:
     """Adds coefficient column to data frame. Compatible with the pandas ``pipe()``
     method.
@@ -110,25 +133,69 @@ def multiply_interaction_signs_and_neighbor_count(
         interactions.
     :return: A copy of input ``data_frame`` with the coefficient column added.
     """
-    return data_frame \
-        .merge(interaction_signs_df, on=["i", "j"]) \
-        .sort_values("pattern") \
+    return (
+        data_frame.merge(interaction_signs_df, on=["i", "j"])
+        .sort_values("pattern")
         .assign(coefficient=lambda x: x["sign"] * x["n"])
+    )
 
 
-def group_subspecie_pairs_and_rank_by_distance(data_frame: DataFrame) -> DataFrame:
+def group_subspecie_pairs_and_rank_by_distance(
+    data_frame: DataFrame, sublattice_pairs: DataFrame
+) -> DataFrame:
     """Adds rank column to data frame that sorts subspecie pairs by neighbor distance.
     Compatible with the pandas ``pipe()`` method.
 
     :param data_frame: A pandas ``DataFrame`` of neighbor counts aggregated over
         site-index pairs and separation distances.
+    :param sublattice_pairs: A pandas ``DataFrame`` of unique sublattice pairs.
     :return: A copy of input ``data_frame`` with the rank column added.
     """
+    return data_frame.merge(
+        sublattice_pairs, on=["subspecies_i", "subspecies_j", "distance_bin"]
+    )
+
+
+def apply_distance_filter(
+    data_frame: DataFrame, distance_filter: Optional[Dict[str, List[float]]]
+) -> DataFrame:
+    """Filters the data frame to only include specific interaction pairs in the model.
+    Compatible with the pandas ``pipe()`` method.
+
+    :param data_frame: A pandas ``DataFrame`` of neighbor counts aggregated over
+        site-index pairs and separation distances.
+    :param distance_filter: A dictionary that defines pair distances to keep in the
+        model. Any pair not found int he dictionary is filtered out. The dictionary keys
+        define named groups of pair distances to keep, which subsequently are used for
+        naming the interaction parameters.
+    :return: A copy of input ``data_frame`` filtered to only include specific distance
+        pairs and a filter_label column added.
+    """
     df: DataFrame = data_frame.copy()
-    df["rank"] = df \
-        .groupby(["subspecies_i", "subspecies_j"]) \
-        .apply(lambda x: x[["distance_bin"]].rank(method="dense")) \
-        .apply(lambda x: pd.to_numeric(arg=x, downcast="integer"))
+
+    if distance_filter:
+        filtered_df_list = []
+        number_distance_groups = len(distance_filter.keys())
+
+        for filter_label, distance_list in distance_filter.items():
+            df2 = df[
+                df["distance_bin"].apply(
+                    lambda x: any([distance in x for distance in distance_list])
+                )
+            ]
+
+            if number_distance_groups > 1:
+                df2 = df2.assign(filter_label=filter_label)
+
+            else:
+                df2 = df2.assign(filter_label="")
+
+            filtered_df_list.append(df2.copy())
+
+        df = pd.concat(filtered_df_list).reset_index(drop=True)
+
+    else:
+        df = df.assign(filter_label="")
 
     return df
 
@@ -141,9 +208,17 @@ def label_interaction_parameters(data_frame: DataFrame) -> DataFrame:
         site-index pairs and separation distances ranked by subspecies pairs.
     :return: A copy of input ``data_frame`` with the parameter_name column added.
     """
-    df = data_frame.copy()
+    df: DataFrame = data_frame.sort_values(
+        ["pattern", "filter_label", "distance_bin"]
+    ).assign(
+        rank=lambda x: x.groupby(["filter_label"])
+        .apply(lambda y: y[["rank"]].rank(method="dense"))
+        .apply(lambda y: pd.to_numeric(arg=y, downcast="integer"))
+    ).reset_index(
+        drop=True
+    )
 
-    parameter_names: Series = "J" + df["rank"].astype(str)
+    parameter_names: Series = "J" + df["filter_label"] + df["rank"].astype(str)
 
     single_specie_check: Series = df["subspecies_i"] == df["subspecies_j"]
     single_specie: bool = single_specie_check.all()
@@ -157,11 +232,10 @@ def label_interaction_parameters(data_frame: DataFrame) -> DataFrame:
 
 
 def aggregate_interaction_coefficients(
-    data_frame: DataFrame,
-    num_sites: int,
+    data_frame: DataFrame, num_sites: int
 ) -> DataFrame:
     """Aggregates interaction coefficients by summing them within groups defined by
-    the magnetic patterns and interaction parametres. Compatible with the pandas
+    the magnetic patterns and interaction parameters. Compatible with the pandas
     ``pipe()`` method.
 
     :param data_frame: A pandas ``DataFrame`` of interaction coefficients and parameters
@@ -170,12 +244,13 @@ def aggregate_interaction_coefficients(
     :return: A data frame where the interaction coefficients were summed within
         groups defined by the magnetic patterns and interaction parameters.
     """
-    return data_frame \
-        .groupby(["pattern", "parameter_name"]) \
-        .apply(lambda x: np.sum(x[["coefficient"]]) / num_sites) \
-        .reset_index() \
-        .sort_values(by=["pattern", "parameter_name"]) \
+    return (
+        data_frame.groupby(["pattern", "parameter_name"])
+        .apply(lambda x: np.sum(x[["coefficient"]]) / num_sites)
+        .reset_index()
+        .sort_values(by=["pattern", "parameter_name"])
         .loc[:, ["pattern", "parameter_name", "coefficient"]]
+    )
 
 
 def build_magnetic_patterns_data_frame(
@@ -189,14 +264,18 @@ def build_magnetic_patterns_data_frame(
         model.
     :return: A pandas ``DataFrame`` labeling and specifying magnetic patterns.
     """
-    return DataFrame(data=magnetic_patterns) \
-        .reset_index(level=0) \
-        .rename(columns={"index": "site"}) \
-        .melt(id_vars=["site"],
-              value_vars=list(magnetic_patterns.keys()),
-              var_name="pattern",
-              value_name="spin") \
+    return (
+        DataFrame(data=magnetic_patterns)
+        .reset_index(level=0)
+        .rename(columns={"index": "site"})
+        .melt(
+            id_vars=["site"],
+            value_vars=list(magnetic_patterns.keys()),
+            var_name="pattern",
+            value_name="spin",
+        )
         .loc[:, ["pattern", "site", "spin"]]
+    )
 
 
 def spread_parameter_name_column(data_frame: DataFrame) -> DataFrame:
@@ -207,9 +286,9 @@ def spread_parameter_name_column(data_frame: DataFrame) -> DataFrame:
         within groups defined by the magnetic patterns and interaction parameters.
     :return: A data frame with the parameter names pivoted into their own columns.
     """
-    df: DataFrame = data_frame \
-        .pivot(index="pattern", columns="parameter_name", values="coefficient") \
-        .reset_index()
+    df: DataFrame = data_frame.pivot(
+        index="pattern", columns="parameter_name", values="coefficient"
+    ).reset_index()
 
     df.columns.name = ""
 

--- a/neighbormodels/structure.py
+++ b/neighbormodels/structure.py
@@ -23,8 +23,7 @@ def from_parameters(structure_parameters: StructureParameters) -> Structure:
     :return: A pymatgen ``Structure`` object.
     """
     cell_lattice: Lattice = Lattice.from_lengths_and_angles(
-        abc=structure_parameters.abc,
-        ang=structure_parameters.ang,
+        abc=structure_parameters.abc, ang=structure_parameters.ang
     )
 
     cell_structure: Structure = Structure.from_spacegroup(
@@ -46,18 +45,14 @@ def from_file(structure_file: str) -> Structure:
     :return: A pymatgen ``Structure`` object.
     """
     cell_structure: Structure = Structure.from_file(
-        filename=structure_file,
-        primitive=False,
-        sort=False,
-        merge_tol=0.01,
+        filename=structure_file, primitive=False, sort=False, merge_tol=0.01
     )
 
     return cell_structure
 
 
 def label_subspecies(
-    cell_structure: Structure,
-    site_indices: Union[List[int], int] = [],
+    cell_structure: Structure, site_indices: Union[List[int], int] = []
 ) -> None:
     """Toggles subspecies grouping on the specified site indices. Sites not found in
     the list are labeled with the atomic species name.
@@ -70,19 +65,16 @@ def label_subspecies(
         site_indices = [site_indices]
 
     site_properties_subspecies: List[str] = get_subspecies_labels(
-        cell_structure=cell_structure.copy(),
-        site_indices=site_indices,
+        cell_structure=cell_structure.copy(), site_indices=site_indices
     )
 
     cell_structure.add_site_property(
-        property_name="subspecie",
-        values=site_properties_subspecies,
+        property_name="subspecie", values=site_properties_subspecies
     )
 
 
 def get_subspecies_labels(
-    cell_structure: Structure,
-    site_indices: List[int],
+    cell_structure: Structure, site_indices: List[int]
 ) -> List[Union[str, None]]:
     """Generates subspecies labels using the provided site indices. Sites not found in
     the list are labeled with the atomic species name.

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ with open('README.rst', 'rt', encoding='utf8') as f:
     readme = f.read()
 
 name = "neighbormodels"
-version = "0.1"
-release = "0.1.0"
+version = "0.2"
+release = "0.2.0"
 
 setuptools.setup(
     name=name,


### PR DESCRIPTION
New feature
-----------

distance_filter is a new argument for the build_model function that allows the
user to pass a dictionary containing pair distances. Any pairs whose separation
distance is given (within the tolerance of the distance bins) will be kept, all
other pairs will be removed. If distance_filter is not specified, then the
standard behavior of including all pairs within the distance r is assumed.

Refactoring
-----------

Grouping and ranking the distance bins now happens as part of the
count_neighbors routine. This information is then joined to the main neighbor
counts data frame when building the model coefficients data frame with the
build_model function.

Some functions and attributes were renamed to be more consistent with
refactorings that I implemented in sPyns.

All code has been passed through the Black code formatter.